### PR TITLE
Change dropbutton arrow to fit with other arrows in app

### DIFF
--- a/lib/assets/javascripts/templates/dropbutton.jst.eco
+++ b/lib/assets/javascripts/templates/dropbutton.jst.eco
@@ -1,6 +1,5 @@
 <a class="drpb-main" href="<%= @functionator(@main_button.onclick) %>"><%= @main_button.label %></a>
-<a href="#" class="drpb-btn">
-  &nbsp;
+<a href="#" class="drpb-btn icon-angle-down">
 </a>
 
 <div class="drpb-drop">

--- a/lib/assets/stylesheets/atlas_assets/_dropbutton.scss
+++ b/lib/assets/stylesheets/atlas_assets/_dropbutton.scss
@@ -30,7 +30,6 @@
   .drpb-btn {
     border-left: 1px solid $defaultBorderColor;
     width: 20px;
-    background: image-url('chosen-sprite.png') 4px 5px no-repeat $defaultBackgroundColor;
 
     &:hover, &.drop-enabled {
       background-color: $lightest_blue;

--- a/lib/atlas_assets/version.rb
+++ b/lib/atlas_assets/version.rb
@@ -1,5 +1,5 @@
 module Atlas
 	module Assets
-		VERSION = "0.8.3"
+		VERSION = "0.8.4"
 	end
 end


### PR DESCRIPTION
Currently the dropbutton arrow looks like this:

![screen shot 2014-08-27 at 10 09 50 am](https://cloud.githubusercontent.com/assets/2559233/4060909/d93f3334-2df3-11e4-901f-f677d6b474ad.png)

The arrow doesn't fit with the branch dropdown or a lot of other aspects of Atlas, so this changes the drop arrow to look like

![screen shot 2014-08-27 at 10 09 17 am](https://cloud.githubusercontent.com/assets/2559233/4060918/ec919fda-2df3-11e4-92ca-39071f85a8d8.png)
