### PR TITLE
Button disable

### DIFF
--- a/docs/_posts/2013-05-17-buttons.md
+++ b/docs/_posts/2013-05-17-buttons.md
@@ -36,6 +36,7 @@ Variations
 <p><a href="#" class="btn btn-error">Error</a></p>
 <p><a href="#" class="btn btn-disabled">Disabled</a></p>
 <a href="#" class="btn info">Info without btn-prefix in class</a>
+<p><a href="#" class="btn btn-info btn-disabled">Info button, disabled</a></p>
 
 
 ~~~html
@@ -46,6 +47,7 @@ Variations
 <a href="#" class="btn btn-error">Error</a>
 <a href="#" class="btn btn-disabled">Disabled</a>
 <a href="#" class="btn info">Info without btn-prefix in class</a>
+<a href="#" class="btn btn-info btn-disabled">Info button, disabled</a>
 ~~~
 
 

--- a/lib/assets/stylesheets/atlas_assets/_buttons.scss
+++ b/lib/assets/stylesheets/atlas_assets/_buttons.scss
@@ -127,6 +127,8 @@ _________________________________________________________________ */
 .btn.btn-disabled, .btn.disabled {
   cursor: not-allowed;
 	color: $mid_gray;
+  background-color: $defaultBackgroundColor;
+  border-color: $defaultBorderColor;
 
   &:hover {
     border: 1px solid $defaultBorderColor;

--- a/lib/atlas_assets/version.rb
+++ b/lib/atlas_assets/version.rb
@@ -1,5 +1,5 @@
 module Atlas
 	module Assets
-		VERSION = "0.8.11"
+		VERSION = "0.8.12"
 	end
 end


### PR DESCRIPTION
The `.btn-disabled` style did not set background colors, so would require unsetting the other `.btn-` styles to appear disabled. This fixes that:

![screen shot 2015-01-05 at 1 26 52 pm](https://cloud.githubusercontent.com/assets/2559233/5617634/bbfab0ee-94de-11e4-874a-91a628615f53.png)
