### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    versioning-strategy: lockfile-only


### PR DESCRIPTION
This commit enables Dependabot to create PRs to keep our dependencies up to date. The YAML is copied directly from the parent repo [orm-atlas](https://github.com/oreillymedia/orm-atlas/edit/main/.github/dependabot.yml).